### PR TITLE
Add item price field to frontend.

### DIFF
--- a/frontend/src/app/Inventory/Item.tsx
+++ b/frontend/src/app/Inventory/Item.tsx
@@ -55,7 +55,7 @@ const Item: React.FC<ItemProps> = ({ item, updateItem, fetchItems }) => {
     }
 
     const categoryValue = categorySelectValue(app.categories, copy.categoryId);
-    const { product_name, name, weight_unit, weight } = copy;
+    const { product_name, name, weight_unit, weight, price } = copy;
     return (
         <>
             <Grid>
@@ -100,6 +100,13 @@ const Item: React.FC<ItemProps> = ({ item, updateItem, fetchItems }) => {
                             }}
                             style={inlineStyles}/>
                 </PairGrid>
+                <div>
+                    <Input value={price || ''}
+                           placeholder="price"
+                           onChange={v => update('price', v)}
+                           onBlur={handleSave}
+                           style={inlineStyles}/>
+                </div>
                 <div className="align-right">
                     <a onClick={() => setEditVisible(true)}>edit</a>
                 </div>

--- a/frontend/src/app/components/EditItem/index.tsx
+++ b/frontend/src/app/components/EditItem/index.tsx
@@ -53,7 +53,7 @@ const EditForm: React.FC<FormSpecs.Props> = (
         </ButtonGroup>
     );
 
-    const { product_name, name, weight_unit, weight, product_url } = record;
+    const { product_name, name, weight_unit, weight, price, product_url } = record;
     return (
         <Modal
             title={<ModalTitle>Edit Item</ModalTitle>}
@@ -97,6 +97,12 @@ const EditForm: React.FC<FormSpecs.Props> = (
                             onChange={(option: Option<string>) => updateItem('weight_unit', option.value)}/>
                 </Col>
             </Row>
+
+            <Input label="Price"
+                  type="number"
+                   placeholder="0.00"
+                   value={price || ''}
+                   onChange={v => updateItem('price', v)}/>
 
             <Input label="Product URL"
                    placeholder="https://osprey.com"

--- a/frontend/src/app/components/ItemForm/ItemForm.tsx
+++ b/frontend/src/app/components/ItemForm/ItemForm.tsx
@@ -39,6 +39,7 @@ const ItemForm: React.FC<FormSpecs.Props> = ({ createItem, exportCsv, onSubmit }
                 product_name: '',
                 weight: undefined,
                 weight_unit: default_weight_unit,
+                price: undefined,
                 product_url: '',
                 newCategory: false
             }}
@@ -121,6 +122,12 @@ const ItemForm: React.FC<FormSpecs.Props> = ({ createItem, exportCsv, onSubmit }
                                     onChange={(option: Option<string>) => setFieldValue('weight_unit', option.value)}/>
                             </Col>
                         </Row>
+                        <Input
+                            label="Price"
+                            value={values.price || ''}
+                            placeholder="0.00"
+                            onChange={v => setFieldValue('price', v)}
+                        />
                         <Input
                             label="Product URL"
                             value={values.product_url || ''}

--- a/frontend/src/styles/grid.ts
+++ b/frontend/src/styles/grid.ts
@@ -3,7 +3,7 @@ import styled from "styled-components";
 
 export const Grid = styled.div`
   display: grid;
-  grid-template-columns: 200px minmax(200px, auto) 160px 160px 30px;
+  grid-template-columns: 160px minmax(200px, auto) 160px 140px 60px 30px;
   grid-template-rows: auto;
   grid-column-gap: 16px;
   align-items: center;

--- a/frontend/src/types/item.ts
+++ b/frontend/src/types/item.ts
@@ -7,6 +7,7 @@ export interface BaseItem {
     product_name?: string;
     weight?: number;
     weight_unit?: WeightUnit;
+    price?: number;
     product_url?: string;
 }
 


### PR DESCRIPTION
Addresses two issues: #12 #18 

I can open a PR for different currencies, with USD default, following the existing weight unit pattern. But not sure if this would just add clutter to UI. I assume that most people don't track their items in multiple currencies (like they might do for weight units). It'd also add quite a bit of complexity to support currency conversion.