### PR TITLE
Allow users to make a copy of a Pack

### DIFF
--- a/api/controllers/pack.js
+++ b/api/controllers/pack.js
@@ -200,16 +200,7 @@ router.post('/copy-pack', authenticate, (req, res) => {
                             ]
                         })
                         .then(pack => {
-                            models.Pack.create({ userId: req.user.id,
-                                                title: "Copy of " + pack.title,
-                                                public: pack.public,
-                                                description: pack.description,
-                                                duration: pack.duration,
-                                                duration_unit: pack.duration_unit,
-                                                temp_range: pack.temp_range,
-                                                season: pack.season,
-                                                gender: pack.gender
-                                                })
+                            models.Pack.create({ ...pack, userId: req.user.id, title: "Copy of " + pack.title })
                             .then(newPack => {
                                 //associate items by id
                                 const assocItems = pack.items.map(item => ({

--- a/frontend/src/app/Profile/Profile.tsx
+++ b/frontend/src/app/Profile/Profile.tsx
@@ -44,6 +44,12 @@ class Profile extends React.Component<ProfileSpecs.Props, ProfileSpecs.State> {
             .catch(() => alertError({ message: 'Error while deleting pack.' }))
     };
 
+    copyPack = (id: number) => {
+        this.props.copyPack(id)
+            .then(() => this.fetchPacks())
+            .catch(() => alertError({ message: 'Error while copying pack.' }))
+    };
+
     render() {
         const { user: { username, id, default_weight_unit }, updateUser, fetchUser } = this.props;
         const { loading, packs } = this.state;
@@ -56,7 +62,7 @@ class Profile extends React.Component<ProfileSpecs.Props, ProfileSpecs.State> {
                     <Grid>
                         <div className="two-thirds">
                             <h3>Packs</h3>
-                            <PackList loading={loading} packs={packs} currentUserId={id} deletePack={this.deletePack}/>
+                            <PackList loading={loading} packs={packs} currentUserId={id} deletePack={this.deletePack} copyPack={this.copyPack}/>
                         </div>
                         <div className="third">
                             <h3>Settings</h3>

--- a/frontend/src/app/Profile/index.tsx
+++ b/frontend/src/app/Profile/index.tsx
@@ -28,6 +28,7 @@ class ProfileContainer extends React.Component<RouteComponentProps> {
                             <Profile getPacks={app.api.PackService.getUserPacks}
                                      updateUser={app.api.UserService.update}
                                      deletePack={app.api.PackService.delete}
+                                     copyPack={app.api.PackService.copyPack}
                                      fetchUser={app.fetchUser}
                                      user={app.userInfo}/>
                         </PageWrapper>

--- a/frontend/src/app/Profile/types.d.ts
+++ b/frontend/src/app/Profile/types.d.ts
@@ -1,4 +1,4 @@
-import { Delete, GetUserPacks } from "types/api/pack";
+import { CopyPack, Delete, GetUserPacks } from "types/api/pack";
 import { Update } from "types/api/user";
 import { PackOverview } from "types/pack";
 import { User } from "types/user";
@@ -7,6 +7,7 @@ export declare module ProfileSpecs {
     export interface OwnProps {
         getPacks: GetUserPacks;
         deletePack: Delete;
+        copyPack: CopyPack;
         updateUser: Update;
         fetchUser: () => void;
         user: User;

--- a/frontend/src/app/components/PackList/PackItem.tsx
+++ b/frontend/src/app/components/PackList/PackItem.tsx
@@ -12,9 +12,10 @@ interface Props {
     pack: PackOverview;
     currentUserId?: number;
     deletePack?: (id: number) => void;
+    copyPack?: (id:number) => void;
 }
 
-const PackItem: React.FC<Props & RouteComponentProps> = ({ pack, currentUserId, deletePack }) => {
+const PackItem: React.FC<Props & RouteComponentProps> = ({ pack, currentUserId, deletePack, copyPack }) => {
     const { id, title } = pack;
 
     const metadata = () => {
@@ -36,6 +37,12 @@ const PackItem: React.FC<Props & RouteComponentProps> = ({ pack, currentUserId, 
         }
     };
 
+    function copy() {
+        if (copyPack) {
+            copyPack(pack.id);
+        }
+    }
+
     const userOptions = () => {
         if (pack.user.id !== currentUserId) {
             return null;
@@ -45,6 +52,7 @@ const PackItem: React.FC<Props & RouteComponentProps> = ({ pack, currentUserId, 
             <UserOptions>
                 <Link to={getPackPath(id, title)}>view</Link>
                 <Link to={`/pack/${id}`}>edit</Link>
+                <a href="#" onClick={copy}>copy</a>
                 <Popconfirm title="Are you sure you want to delete this pack?"
                             okText="Delete"
                             placement="bottom"

--- a/frontend/src/app/components/PackList/index.tsx
+++ b/frontend/src/app/components/PackList/index.tsx
@@ -10,9 +10,10 @@ interface Props {
     loading: boolean;
     currentUserId?: number;
     deletePack?: (id: number) => void;
+    copyPack?: (id: number) => void;
 }
 
-const PackList: React.FC<Props> = ({ packs, loading, currentUserId, deletePack }) => {
+const PackList: React.FC<Props> = ({ packs, loading, currentUserId, deletePack, copyPack }) => {
     if (loading) {
         return <Loading size="large"/>
     }
@@ -25,7 +26,7 @@ const PackList: React.FC<Props> = ({ packs, loading, currentUserId, deletePack }
 
     return (
         <div>
-            {packs.map(p => <Item key={p.id} pack={p} currentUserId={currentUserId} deletePack={deletePack} />)}
+            {packs.map(p => <Item key={p.id} pack={p} currentUserId={currentUserId} deletePack={deletePack} copyPack={copyPack} />)}
         </div>
     )
 };

--- a/frontend/src/lib/api/pack.ts
+++ b/frontend/src/lib/api/pack.ts
@@ -10,7 +10,8 @@ import {
     AddItem,
     RemoveItem,
     ExportItems,
-    GetUserPacks
+    GetUserPacks,
+    CopyPack
 } from "types/api/pack";
 import { Pack as PackPayload, PackOverview } from "types/pack";
 import { PackItemAttr } from "types/item";
@@ -61,5 +62,10 @@ export default class Pack implements PackService {
     exportItems: ExportItems = packId => {
         return this.api.get(`${this.baseUrl}/export/${packId}`)
             .then((resp: AxiosResponse<File>) => resp.data);
+    }
+
+    copyPack: CopyPack = (packId: number) => {
+        return this.api.post(`${this.baseUrl}/copy-pack/`, {packId} )
+            .then((resp: AxiosResponse<number>) => resp.data);
     }
 }

--- a/frontend/src/types/api/pack.ts
+++ b/frontend/src/types/api/pack.ts
@@ -10,6 +10,7 @@ export interface PackService {
     addItem: AddItem;
     removeItem: RemoveItem;
     exportItems: ExportItems;
+    copyPack: CopyPack;
 }
 
 export interface Get {
@@ -42,4 +43,8 @@ export interface RemoveItem {
 
 export interface ExportItems {
     (packId: number): Promise<File>;
+}
+
+export interface CopyPack {
+    (packId: number): Promise<number>;//returns the id of the new pack
 }


### PR DESCRIPTION
![packlist](https://user-images.githubusercontent.com/1940054/103722280-9ac51880-4f9d-11eb-8d11-9fd85ea70c47.png)
After clicking `copy`:
![packlist2](https://user-images.githubusercontent.com/1940054/103722286-9c8edc00-4f9d-11eb-8d12-2d3317b491bb.png)

All user entered data and items are copied to the new pack. The new pack's name has "Copy of" prepended to the original pack name. 

Here's the original pack:
![original](https://user-images.githubusercontent.com/1940054/103722276-9993eb80-4f9d-11eb-887e-05a0e2d0feea.png)
And the copied pack:
![copy](https://user-images.githubusercontent.com/1940054/103722289-9dc00900-4f9d-11eb-8589-c93047ab54df.png)


I don't think this needs any additional security considerations. The request is an authenticated post and before any data is created, the controller checks to make sure the list that is being copied belongs to the one making the request. 



