### PR TITLE
Modify pack view to display data more condensed

### DIFF
--- a/frontend/src/app/Pack/Items.tsx
+++ b/frontend/src/app/Pack/Items.tsx
@@ -57,19 +57,20 @@ const Items: React.FC<ItemsProps> = ({ items, unit }) => {
                                     {notes}
                                 </ItemNotes>
                             );
+                            let quantityString = parseFloat(quantity.toString());
                             return (
                                 <Row gutter={16} key={item.id} className="item-row">
-                                    <Col span={18}>
+                                    <Col span={6}>
                                         <ItemName>
+                                            <ItemQuantity>{quantityString} x </ItemQuantity>
                                             {name}
                                         </ItemName>
+                                        {NotesRow}
+                                    </Col>
+                                    <Col span={12}>
                                         <ItemDescription>
                                             {itemDesc(product_url, product_name)}
                                         </ItemDescription>
-                                        <ItemQuantity>
-                                            Quantity: {quantity}
-                                        </ItemQuantity>
-                                        {NotesRow}
                                     </Col>
                                     <Col span={2} className="align-right">
                                         {worn && (

--- a/frontend/src/app/Pack/Pack.tsx
+++ b/frontend/src/app/Pack/Pack.tsx
@@ -20,7 +20,7 @@ import Items from './Items';
 
 import { getWeightByCategory } from 'lib/utils/weight';
 
-import { Credit, PackWrapper, SectionHeader, SectionTitle, TripDescription, ItemsFooter } from "./styles";
+import { Credit, PackWrapper, SectionHeader, SectionTitle, TripDescription } from "./styles";
 
 const Pack: React.FC<PackSpecs.Props> = ({ getPack, weightUnit, packId }) => {
     const [loading, setLoading] = React.useState<boolean>(true);
@@ -113,12 +113,6 @@ const Pack: React.FC<PackSpecs.Props> = ({ getPack, weightUnit, packId }) => {
                     </div>
                 </SectionHeader>
                 <Items items={pack.items} unit={unit}/>
-                <ItemsFooter>
-                    <WeightSelector
-                        unit={unit}
-                        items={pack.items}
-                        selectUnit={unit => setUnit(unit)}/>
-                </ItemsFooter>
             </PackWrapper>
         </DocumentTitle>
     );

--- a/frontend/src/app/Pack/styles.ts
+++ b/frontend/src/app/Pack/styles.ts
@@ -55,6 +55,7 @@ export const TripDescription = styled.p`
 `;
 
 export const ItemName = styled.h4`
+    display: inline;
     font-family: "Open Sans", sans-serif;
     font-weight: 700;
     font-size: 1em;
@@ -63,19 +64,21 @@ export const ItemName = styled.h4`
     
     span {
       color: #888;
-      font-size: .9rem;
+      font-size: 1rem;
       margin-left: 8px;
     }
 `;
 
 export const ItemDescription = styled.p`
-  font-size: .85em;
+  font-size: 1em;
   color: #888;
   margin-bottom: 0;
   line-height: 1rem;
 `;
 
-export const ItemQuantity = styled(ItemDescription)``;
+export const ItemQuantity = styled(ItemDescription)`
+  display:inline;
+`;
 
 export const ItemNotes = styled.p`
   line-height: 1.35rem;
@@ -96,8 +99,11 @@ export const ItemsFooter = styled.div`
 
 export const CategorySection = styled.div`
   .item-row {
-    padding: 8px;
+    padding: 5px;
     border-bottom: 1px dashed #EEE;
+    &:hover {
+      background-color: #F0F7FA;
+    }
   }
   
   .item-row:last-of-type {


### PR DESCRIPTION
- Add hover color to item rows
- Put quantity before the item name
- Cut off trailing 0s from quantity
- Put item description in its own column
- Remove footer with redundant weight unit picker

A user requested this on Reddit and I certainly agree. 
![request](https://user-images.githubusercontent.com/1940054/104135713-d37b3e00-535f-11eb-8051-e279b2d0dc9d.png)

With these changes, users can see almost 50% more content in the same space. 
![before-after](https://user-images.githubusercontent.com/1940054/104135840-6ddb8180-5360-11eb-8259-b221574362e1.png)

When hovering over an item: 
![hover](https://user-images.githubusercontent.com/1940054/104135721-d9711f00-535f-11eb-8481-e79091c294d3.png)
