### PR TITLE
Add unsaved changes alert for pack changes

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -63,6 +63,7 @@
     "react-ga": "^2.5.6",
     "react-linkify": "^1.0.0-alpha",
     "react-router-dom": "^5.0.1",
+    "react-router-navigation-confirm": "^1.1.7",
     "react-select": "^3.1.0",
     "recharts": "^1.7.1",
     "resolve": "1.10.0",

--- a/frontend/src/app/Inventory/Item.tsx
+++ b/frontend/src/app/Inventory/Item.tsx
@@ -20,7 +20,7 @@ interface ItemProps {
     updateItem: Update;
 }
 
-const Item: React.FC<ItemProps> = ({ item, updateItem, fetchItems }) => {
+const Item: React.FC<ItemProps> = ({item, updateItem, fetchItems}) => {
     const app = React.useContext(AppContext);
     const firstRender = React.useRef(true);
     const [copy, setCopy] = React.useState<ItemType>(item);
@@ -36,26 +36,27 @@ const Item: React.FC<ItemProps> = ({ item, updateItem, fetchItems }) => {
     }, [catId, wUnit]);
 
     function update(key: string, value: any) {
-        const i = Object.assign({}, { ...copy, [key]: value });
+        const i = Object.assign({}, {...copy, [key]: value});
         setCopy(i);
     }
 
     function handleSave() {
         if (!copy.name || isEqual(copy, item)) return;
         const newCategory = !app.categories.map(c => c.id).includes(copy.categoryId);
-        updateItem({ ...copy, newCategory })
+        const withDefaults = {...copy, price: copy.price || 0, weight: copy.weight || 0};
+        updateItem({...withDefaults, newCategory})
             .then(newItem => {
                 setCopy(newItem);
-                alertSuccess({ message: 'Item Updated.', duration: 2 });
+                alertSuccess({message: 'Item Updated.', duration: 2});
                 if (newCategory) {
                     app.fetchUser();
                 }
             })
-            .catch(() => alertWarn({ message: 'Error updating item.' }));
+            .catch(() => alertWarn({message: 'Error updating item.'}));
     }
 
     const categoryValue = categorySelectValue(app.categories, copy.categoryId);
-    const { product_name, name, weight_unit, weight, price } = copy;
+    const {product_name, name, weight_unit, weight, price} = copy;
     return (
         <>
             <Grid>
@@ -100,7 +101,8 @@ const Item: React.FC<ItemProps> = ({ item, updateItem, fetchItems }) => {
                             }}
                             style={inlineStyles}/>
                 </PairGrid>
-                <div>
+                <div style={{ display: 'flex', alignItems: 'center' }}>
+                    $
                     <Input value={price || ''}
                            placeholder="price"
                            onChange={v => update('price', v)}

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -9,6 +9,7 @@ import App from './App';
 import * as serviceWorker from './serviceWorker';
 import { AppProvider } from './AppContext';
 import WithAnalytics from 'app/components/higher-order/with-analytics';
+import { HistoryListener } from 'react-router-navigation-confirm';
 
 import { theme } from 'styles/theme';
 import 'styles/style.less';
@@ -22,7 +23,9 @@ ReactDOM.render(
                 <Router>
                     <Route render={(props) => (
                         <WithAnalytics {...props}>
-                            <App/>
+                            <HistoryListener>
+                                <App/>
+                            </HistoryListener>
                         </WithAnalytics>
                     )}/>
                 </Router>

--- a/frontend/src/styles/style.less
+++ b/frontend/src/styles/style.less
@@ -116,6 +116,20 @@ body {
   }
 }
 
+.navigation-confirm-modal-footer {
+  font-family: "Open Sans", sans-serif;
+  margin:.3em;
+  float:right;
+  button {
+    margin:.3em;
+  }
+}
+
+.navigation-confirm-modal-body {
+  font-family: "Open Sans", sans-serif;
+  margin: .8em .5em;
+}
+
 @media screen and (max-width: 660px) {
   html {
     font-size: .85em;


### PR DESCRIPTION
Show a warning if there are pending unsaved changes in the pack edit view when trying to navigate away. 
My screen recorder won't show it, but if you try to close the tab or refresh it will do a normal JS alert to prevent the page from closing. Closes #10. 

![Screenshot 2021-01-10 221414](https://user-images.githubusercontent.com/1940054/104144447-3a651b00-5391-11eb-9343-4f2cefc958dd.png)

https://user-images.githubusercontent.com/1940054/104144554-9cbe1b80-5391-11eb-971d-040ec9dd47cf.mp4






