### PR TITLE
Remove "unsaved changes" popup when creating a pack

### DIFF
--- a/frontend/src/app/PackForm/PackForm.tsx
+++ b/frontend/src/app/PackForm/PackForm.tsx
@@ -146,6 +146,7 @@ const PackForm: React.FC<PackFormSpecs.Props> = ({
                         createPack(payload)
                             .then(resp => {
                                 alertSuccess({message: 'Packing list created'});
+                                setHasPendingChanges(false);
                                 history.push(`/pack/${resp.id}`);
                             })
                             .catch(err => console.log(err));


### PR DESCRIPTION
Fixes a bug where the "You have unsaved changes" popup would show when creating a new pack. 

