### PR TITLE
Move pack notes (and other small things)

### DIFF
--- a/frontend/src/app/Pack/Items.tsx
+++ b/frontend/src/app/Pack/Items.tsx
@@ -65,11 +65,11 @@ const Items: React.FC<ItemsProps> = ({ items, unit }) => {
                                             <ItemQuantity>{quantityString} x </ItemQuantity>
                                             {name}
                                         </ItemName>
-                                        {NotesRow}
                                     </Col>
                                     <Col span={12}>
                                         <ItemDescription>
                                             {itemDesc(product_url, product_name)}
+                                            {NotesRow}
                                         </ItemDescription>
                                     </Col>
                                     <Col span={2} className="align-right">

--- a/frontend/src/app/Pack/Items.tsx
+++ b/frontend/src/app/Pack/Items.tsx
@@ -27,7 +27,7 @@ const Items: React.FC<ItemsProps> = ({ items, unit }) => {
         }
 
         if (url) {
-            const linkLabel = product_name || 'view item';
+            const linkLabel = product_name || 'View product';
             return <a href={url} target="_blank">{linkLabel}</a>
         }
 

--- a/frontend/src/app/components/EditItem/index.tsx
+++ b/frontend/src/app/components/EditItem/index.tsx
@@ -4,6 +4,7 @@ import { Button, Col, Modal, Row, Popconfirm } from "antd";
 import { FormSpecs } from "./types";
 
 import { Input, Select, Option, SelectCreatable } from "app/components/FormFields";
+import { ItemConstants } from "types/item";
 
 import withApi from "app/components/higher-order/with-api";
 import { categoryOptions, weightUnitOptions } from "lib/utils/form";
@@ -65,6 +66,7 @@ const EditForm: React.FC<FormSpecs.Props> = (
                    placeholder="Backpack, Compass, etc..."
                    value={name}
                    onChange={v => updateItem('name', v)}
+                   allowedLength={ItemConstants.name}
             />
 
             <SelectCreatable
@@ -78,6 +80,7 @@ const EditForm: React.FC<FormSpecs.Props> = (
             <Input label="Product Name"
                    placeholder="Osprey Renn 65"
                    value={product_name || ''}
+                   allowedLength={ItemConstants.product_name}
                    onChange={v => updateItem('product_name', v)}/>
 
             <Row gutter={8}>
@@ -109,12 +112,14 @@ const EditForm: React.FC<FormSpecs.Props> = (
                    type="url"
                    value={product_url || ''}
                    onChange={v => updateItem('product_url', v)}
+                   allowedLength={ItemConstants.product_url}
                    />
 
             <Input label="Notes"
                    value={notes || ''}
                    placeholder="Care instructions, further details, etc..."
                    onChange={v => updateItem('notes', v)}
+                   allowedLength={ItemConstants.notes}
                    last={true}/>
         </Modal>
     )

--- a/frontend/src/app/components/ItemForm/ItemForm.tsx
+++ b/frontend/src/app/components/ItemForm/ItemForm.tsx
@@ -144,6 +144,7 @@ const ItemForm: React.FC<FormSpecs.Props> = ({ createItem, exportCsv, onSubmit }
                             value={values.notes || ''}
                             placeholder="Care instructions, further details, etc..."
                             onChange={v => setFieldValue('notes', v)}
+                            allowedLength={ItemConstants.notes}
                         />
                         <Button onClick={submitForm}
                                 disabled={isSubmitting}

--- a/frontend/src/app/components/PackItems/Item.tsx
+++ b/frontend/src/app/components/PackItems/Item.tsx
@@ -8,6 +8,7 @@ import { WornIndicator, ItemRow } from "./styles";
 
 import { ShirtIcon } from "../Icons";
 import { PackItemGrid } from "styles/grid";
+import { PackConstants } from "types/pack";
 
 interface ItemProps {
     item: PackItem;
@@ -60,7 +61,10 @@ const Item: React.FC<ItemProps> = ({ item, removeItem, updateItem }) => {
                 </div>
             </PackItemGrid>
             {displayNotes && (
-                <Textarea value={notes} onChange={v => updateItem(item.id, "notes", v)}/>
+                <Textarea value={notes} 
+                        onChange={v => updateItem(item.id, "notes", v)}
+                        allowedLength={PackConstants.notes}
+                />
             )}
         </ItemRow>
     )

--- a/frontend/src/types/item.ts
+++ b/frontend/src/types/item.ts
@@ -57,5 +57,6 @@ export interface PackItem extends Item {
 export enum ItemConstants {
     name = 200,
     product_name = 500,
+    notes = 500,
     product_url = 500
 }

--- a/frontend/src/types/pack.ts
+++ b/frontend/src/types/pack.ts
@@ -40,5 +40,6 @@ export enum PackConstants {
     title = 300,
     description = 2000,
     temp_range = 255,
+    notes = 1000,
     season = 255
 }


### PR DESCRIPTION
Just a bunch of small improvements.

1. When there are a lot of item notes, they can look quite crowded in the Name column. I suggest moving them to under the Product Name in the Item Description column as there is just more room there and it breaks up the potential of giant amounts of whitespace.

Before:
<img width="836" alt="Screenshot 2021-02-14 at 13 35 35" src="https://user-images.githubusercontent.com/8898786/107878312-87c13480-6ec9-11eb-9e5e-9e0fbacd9392.png">


After:
<img width="841" alt="Screenshot 2021-02-14 at 13 12 50" src="https://user-images.githubusercontent.com/8898786/107877783-5eeb7000-6ec6-11eb-8a69-7c4301b06119.png">

2. In the case that users set a product link, but do not set a product name, I have altered the text slightly:
<img width="843" alt="Screenshot 2021-02-14 at 13 16 14" src="https://user-images.githubusercontent.com/8898786/107877856-d3261380-6ec6-11eb-8935-00ac8399a772.png">

3. I added character counters to notes text fields. Both in the Inventory Item forms and the Pack Item table. Annoyingly, when I added notes to Items, I set the field to 500 characters, not 1000 characters like the Pack 🤦‍♀️ . I can't decide whether this is actually a good thing or not, let me know if you have opinions.

4. I also added character counters to all field in the EditItem form, I was not sure if you omitted those for a reason @darinalleman  as I remember you saying in that PR that you had added it to "some" fields.