### PR TITLE
Quickadd new item on create/edit pack view

### DIFF
--- a/frontend/src/app/PackForm/PackForm.tsx
+++ b/frontend/src/app/PackForm/PackForm.tsx
@@ -98,10 +98,6 @@ const PackForm: React.FC<PackFormSpecs.Props> = ({
         setPackItems(items);
     };
 
-    const createNewItem  = () => {
-        dispatch({type: 'setContent', value: SidebarContent(true)});
-    }
-
     const updateItem = (itemId: number, field: string, value: string | number | boolean) => {
         const items: PackItem[] = Object.assign([], packItems);
         const idx = items.findIndex(item => item.id === itemId);
@@ -110,17 +106,15 @@ const PackForm: React.FC<PackFormSpecs.Props> = ({
         setPackItems(items);
     };
 
+    const createNewItem  = () => {
+        //show the add item view
+        dispatch({type: 'setContent', value: SidebarContent(true)});
+    }
+
     const SidebarContent = (isAddingNewItem: boolean) => {
-        if (!isAddingNewItem) {
-            return <InventorySidebar items={inventory}
-            addItem={addItem}
-            removeItem={removeItem}
-            currentItems={packItems.map(item => item.id)}
-            createNewItem={createNewItem}
-            />
-        }
-        else {
-            return <div>
+        if (isAddingNewItem) {
+            //show the new item form with a FAB to return to the inventory list
+            return <div> 
                 <ItemForm onSubmit={onNewItemCreated}></ItemForm>
                 <FloatingActionButton 
                     icon="rollback"
@@ -129,11 +123,20 @@ const PackForm: React.FC<PackFormSpecs.Props> = ({
                     tooltip="Go back to the inventory list" ></FloatingActionButton>
                 </div>
         }
-        
+        else {
+            //show the inventory list
+            return <InventorySidebar items={inventory}
+            addItem={addItem}
+            removeItem={removeItem}
+            currentItems={packItems.map(item => item.id)}
+            createNewItem={createNewItem}
+            />
+        }
     };
 
     React.useEffect(() => {
         dispatch({type: 'setTitle', value: 'Inventory'});
+        //show the inventory list
         dispatch({type: 'setContent', value: SidebarContent(false)});
         return function cleanup() {
             dispatch({type: 'reset'});
@@ -151,11 +154,13 @@ const PackForm: React.FC<PackFormSpecs.Props> = ({
     }
 
     function onNewItemCreated() {
+        //show the inventory list
         dispatch({type: 'setContent', value: SidebarContent(false)});
         refreshInventoryList(packId);
     }
 
     function cancelNewItem() {
+        //show the inventory list
         dispatch({type: 'setContent', value: SidebarContent(false)});
     }
 

--- a/frontend/src/app/components/FloatingActionButton/index.tsx
+++ b/frontend/src/app/components/FloatingActionButton/index.tsx
@@ -1,0 +1,34 @@
+import * as React from 'react';
+import { Button, Tooltip } from "antd";
+
+interface FloatingActionButtonProps {
+	visible: boolean;
+	onClick: () => void;
+    icon: string;
+    tooltip?: string;
+}
+
+const styles: React.CSSProperties = {
+    position: 'fixed',
+    width: '50px',
+    height: '50px',
+    right: '30px',
+    bottom: '1%',
+    borderRadius: '50px',
+    textAlign: 'center',
+    boxShadow: '2px 2px 3px #999',
+    fontSize: '20px'
+}
+
+const FloatingActionButton: React.FC<FloatingActionButtonProps> = ({ visible, onClick, icon , tooltip}) => {
+  return <Tooltip title={tooltip} placement="left">
+            <Button 
+                icon={icon}
+                type="primary"
+                onClick={onClick}
+                style={styles}>
+            </Button>
+        </Tooltip>
+};
+
+export default FloatingActionButton;

--- a/frontend/src/app/components/InventorySidebar/index.tsx
+++ b/frontend/src/app/components/InventorySidebar/index.tsx
@@ -109,10 +109,6 @@ const InventorySidebar: React.FC<SidebarProps> = ({ items, addItem, removeItem, 
         </Dropdown>
     );
 
-    function addNewItemClick() {
-        createNewItem();  
-    } 
-
     return (
         <>
             <div style={{ padding: '8px 16px' }}>
@@ -125,7 +121,7 @@ const InventorySidebar: React.FC<SidebarProps> = ({ items, addItem, removeItem, 
             <FloatingActionButton 
                 icon="plus"
                 visible={true}
-                onClick={addNewItemClick}
+                onClick={createNewItem}
                 tooltip="Add a new item to your inventory" ></FloatingActionButton>
             <InventoryContainer>
                 {renderInventory()}

--- a/frontend/src/app/components/InventorySidebar/index.tsx
+++ b/frontend/src/app/components/InventorySidebar/index.tsx
@@ -10,15 +10,16 @@ import { searchItems } from "lib/utils/search";
 import { CategoryGroup, InventoryContainer } from "styles/common";
 import { InventoryItem, CategoryLabel, ItemContainer, CategoryHeader } from "./styles";
 import { Input } from "../FormFields";
-
+import FloatingActionButton from '../FloatingActionButton';
 interface SidebarProps {
     items: Item[];
     addItem: (item: Item) => void;
     removeItem: (id: number) => void;
+    createNewItem: () => void;
     currentItems: number[];
 }
 
-const InventorySidebar: React.FC<SidebarProps> = ({ items, addItem, removeItem, currentItems }) => {
+const InventorySidebar: React.FC<SidebarProps> = ({ items, addItem, removeItem, currentItems, createNewItem }) => {
     const categories = getCategories(items);
     const [filterText, setFilterText] = React.useState<string>('');
     const [categoryFilter, setCategoryFilter] = React.useState<Category | null>(null);
@@ -108,6 +109,10 @@ const InventorySidebar: React.FC<SidebarProps> = ({ items, addItem, removeItem, 
         </Dropdown>
     );
 
+    function addNewItemClick() {
+        createNewItem();  
+    } 
+
     return (
         <>
             <div style={{ padding: '8px 16px' }}>
@@ -117,6 +122,11 @@ const InventorySidebar: React.FC<SidebarProps> = ({ items, addItem, removeItem, 
                        onChange={v => setFilterText(v.toString())}
                        last={true}/>
             </div>
+            <FloatingActionButton 
+                icon="plus"
+                visible={true}
+                onClick={addNewItemClick}
+                tooltip="Add a new item to your inventory" ></FloatingActionButton>
             <InventoryContainer>
                 {renderInventory()}
             </InventoryContainer>


### PR DESCRIPTION
Fixes #5 

Adds a new Floating Action Button (FAB) component that will put a circular button at the bottom right corner of the component it's placed in:

![image](https://user-images.githubusercontent.com/1940054/107886671-59465800-6ecf-11eb-826b-632728870c46.png)

Here's a quick demo.

https://user-images.githubusercontent.com/1940054/107886713-c2c66680-6ecf-11eb-9687-505f541fb7bb.mp4

TL;DW: Click on the '+' FAB and the new item sidebar shows. The FAB now shows a return arrow, and clicking it returns the user back to the inventory list. Otherwise, successfully adding a new item will return the user to a refreshed item list.

The only thing I wasn't sure how to do or if it should be done is automatically adding that new item to the pack. Maybe that should just be a separate future task. Thoughts? 