### PR TITLE
Add chart type selector and new pie chart for pack weight breakdown

### DIFF
--- a/frontend/src/app/Pack/Pack.tsx
+++ b/frontend/src/app/Pack/Pack.tsx
@@ -61,7 +61,7 @@ const Pack: React.FC<PackSpecs.Props> = ({ getPack, weightUnit, packId }) => {
                 <>
                     <Statistics pack={pack}/>
                     <CategoryTable data={catWeights} unit={unit}/>
-                    <CategoryChart data={catWeights}/>
+                    <CategoryChart data={catWeights} unit={unit}/>
                 </>
             );
 

--- a/frontend/src/app/components/CategoryChart/index.tsx
+++ b/frontend/src/app/components/CategoryChart/index.tsx
@@ -1,3 +1,4 @@
+import { WeightUnit } from 'enums';
 import * as React from 'react';
 import { ResponsiveContainer, BarChart, XAxis, YAxis, Bar, LabelList, LabelProps, Cell, Pie, PieChart, Tooltip, TooltipProps } from 'recharts';
 
@@ -6,9 +7,10 @@ import { Option, Select } from "../FormFields/";
 
 interface CategoryChartProps {
     data: CategoryItemSpecs[];
+    unit: WeightUnit
 }
 
-const CategoryChart: React.FC<CategoryChartProps> = ({ data }) => {
+const CategoryChart: React.FC<CategoryChartProps> = ({ data, unit }) => {
     const [chartType, setChartType] = React.useState<Option<number>>({value: 0, label: 'Bar Chart'});
 
     if (!data.length) {
@@ -36,7 +38,7 @@ const CategoryChart: React.FC<CategoryChartProps> = ({ data }) => {
 
     const PieToolTip = (props: TooltipProps) =>  {
         if (props.active && props.payload) {
-            const text: string = props.payload[0].name + ': ' + props.payload[0].value + '';
+            const text: string = props.payload[0].name + ': ' + props.payload[0].value + ' ' + unit;
             return ( 
                 <div style={{backgroundColor: '#AAAAA'}}>
                     <span 

--- a/frontend/src/app/components/CategoryChart/index.tsx
+++ b/frontend/src/app/components/CategoryChart/index.tsx
@@ -1,13 +1,16 @@
 import * as React from 'react';
-import { ResponsiveContainer, BarChart, XAxis, YAxis, Bar, LabelList, LabelProps, Cell } from 'recharts';
+import { ResponsiveContainer, BarChart, XAxis, YAxis, Bar, LabelList, LabelProps, Cell, Pie, PieChart, Tooltip, TooltipProps } from 'recharts';
 
 import { CategoryItemSpecs } from "types/category";
+import { Option, Select } from "../FormFields/";
 
 interface CategoryChartProps {
     data: CategoryItemSpecs[];
 }
 
 const CategoryChart: React.FC<CategoryChartProps> = ({ data }) => {
+    const [chartType, setChartType] = React.useState<Option<number>>({value: 0, label: 'Bar Chart'});
+
     if (!data.length) {
         return null;
     }
@@ -31,21 +34,77 @@ const CategoryChart: React.FC<CategoryChartProps> = ({ data }) => {
         );
     };
 
+    const PieToolTip = (props: TooltipProps) =>  {
+        if (props.active && props.payload) {
+            const text: string = props.payload[0].name + ': ' + props.payload[0].value + '';
+            return ( 
+                <div style={{backgroundColor: '#AAAAA'}}>
+                    <span 
+                        style={{
+                            fontSize:'16px',
+                            fontWeight:'bold',
+                            color: props.payload[0].payload.fill,
+                            backgroundColor:'white',
+                            padding:'5px',
+                            borderRadius:'5px'}}>
+                        {text}
+                    </span>
+                </div>
+          );
+        }
+        return null;
+    }
+
+    const pieData = data.map(record => {
+        record.total.value = Number(record.total.value.toFixed(2)); //convert the displayed weight to show only 2 decimal places
+        return record;
+    })
     const height = 40 * data.length;
-    return (
-            <div style={{ height }}>
-                <ResponsiveContainer>
-                    <BarChart data={data} layout="vertical" barCategoryGap={12}>
-                        <YAxis type="category" dataKey="name" tick={false} axisLine={false} tickMargin={0} width={12}/>
-                        <XAxis type="number" dataKey="total.value" tick={false} axisLine={false} height={0} width={0}/>
-                        <Bar dataKey="total.value">
-                            <LabelList dataKey="name" content={CategoryLabel}/>
+    const options = [{value: 0, label: 'Bar Chart'}, {value: 1, label: 'Pie Chart'}];
+
+    function onChartTypeChange(event: Option<number>) {
+        setChartType(event);
+    }
+    
+    const Chart = () => {
+        if (chartType.value == 0) {
+            return <div style={{ height }}>
+            <ResponsiveContainer>
+                <BarChart data={data} layout="vertical" barCategoryGap={12}>
+                    <YAxis type="category" dataKey="name" tick={false} axisLine={false} tickMargin={0} width={12}/>
+                    <XAxis type="number" dataKey="total.value" tick={false} axisLine={false} height={0} width={0}/>
+                    <Bar dataKey="total.value">
+                        <LabelList dataKey="name" content={CategoryLabel}/>
+                        {data.map(rec => <Cell key={rec.id} fill={rec.color}/>)}
+                    </Bar>
+                </BarChart>
+            </ResponsiveContainer>  
+            </div>
+        }
+        else {
+            return <div style={{ height: '250px' }}>
+            <ResponsiveContainer>
+                    <PieChart>
+                        <Pie data={pieData} dataKey="total.value" nameKey="name" cx="50%" cy="50%" innerRadius={50} outerRadius={100}>
                             {data.map(rec => <Cell key={rec.id} fill={rec.color}/>)}
-                        </Bar>
-                    </BarChart>
+                        </Pie>
+                        <Tooltip content={PieToolTip} />
+                    </PieChart>
                 </ResponsiveContainer>
             </div>
-    );
+        }
+    }
+    return <div>
+             <Select 
+                        label="Chart Type"
+                        options={options}
+                        value={chartType}
+                        onChange={onChartTypeChange}
+                        style={{width: '90%', margin: '0 auto'}}
+                />   
+                <Chart></Chart> 
+            </div>
+    
 };
 
 export default React.memo(CategoryChart);

--- a/frontend/src/app/components/CategoryChart/index.tsx
+++ b/frontend/src/app/components/CategoryChart/index.tsx
@@ -97,7 +97,7 @@ const CategoryChart: React.FC<CategoryChartProps> = ({ data, unit }) => {
         }
     }
     return <div>
-                <Radio.Group value={chartType} onChange={onChartChange} style={{textAlign:'center', width:'100%'}}>
+                <Radio.Group value={chartType} onChange={onChartChange} style={{textAlign:'center', width:'100%', marginBottom:'8px'}}>
                     <Radio.Button value='bar'><Icon type="bar-chart" /> Bar Chart</Radio.Button>
                     <Radio.Button value='pie'><Icon type="pie-chart" /> Pie Chart</Radio.Button>
                 </Radio.Group>

--- a/frontend/src/app/components/CategoryChart/index.tsx
+++ b/frontend/src/app/components/CategoryChart/index.tsx
@@ -1,9 +1,10 @@
+import { Icon, Radio } from 'antd';
+import { RadioChangeEvent } from 'antd/lib/radio';
 import { WeightUnit } from 'enums';
 import * as React from 'react';
 import { ResponsiveContainer, BarChart, XAxis, YAxis, Bar, LabelList, LabelProps, Cell, Pie, PieChart, Tooltip, TooltipProps } from 'recharts';
 
 import { CategoryItemSpecs } from "types/category";
-import { Option, Select } from "../FormFields/";
 
 interface CategoryChartProps {
     data: CategoryItemSpecs[];
@@ -11,7 +12,7 @@ interface CategoryChartProps {
 }
 
 const CategoryChart: React.FC<CategoryChartProps> = ({ data, unit }) => {
-    const [chartType, setChartType] = React.useState<Option<number>>({value: 0, label: 'Bar Chart'});
+    const [chartType, setChartType] = React.useState<string>('bar'); //default selected chart type is bar
 
     if (!data.length) {
         return null;
@@ -38,7 +39,7 @@ const CategoryChart: React.FC<CategoryChartProps> = ({ data, unit }) => {
 
     const PieToolTip = (props: TooltipProps) =>  {
         if (props.active && props.payload) {
-            const text: string = props.payload[0].name + ': ' + props.payload[0].value + ' ' + unit;
+            const text: string = props.payload[0].name + ': ' + props.payload[0].value + ' ' + unit; // Category Name: 10 lbs
             return ( 
                 <div style={{backgroundColor: '#AAAAA'}}>
                     <span 
@@ -61,15 +62,14 @@ const CategoryChart: React.FC<CategoryChartProps> = ({ data, unit }) => {
         record.total.value = Number(record.total.value.toFixed(2)); //convert the displayed weight to show only 2 decimal places
         return record;
     })
-    const height = 40 * data.length;
-    const options = [{value: 0, label: 'Bar Chart'}, {value: 1, label: 'Pie Chart'}];
+    const height = 40 * data.length; //height used for bar chart
 
-    function onChartTypeChange(event: Option<number>) {
-        setChartType(event);
+    function onChartChange(event: RadioChangeEvent) {
+        setChartType(event.target.value);
     }
     
     const Chart = () => {
-        if (chartType.value == 0) {
+        if (chartType == 'bar') {
             return <div style={{ height }}>
             <ResponsiveContainer>
                 <BarChart data={data} layout="vertical" barCategoryGap={12}>
@@ -97,16 +97,12 @@ const CategoryChart: React.FC<CategoryChartProps> = ({ data, unit }) => {
         }
     }
     return <div>
-             <Select 
-                        label="Chart Type"
-                        options={options}
-                        value={chartType}
-                        onChange={onChartTypeChange}
-                        style={{width: '90%', margin: '0 auto'}}
-                />   
+                <Radio.Group value={chartType} onChange={onChartChange} style={{textAlign:'center', width:'100%'}}>
+                    <Radio.Button value='bar'><Icon type="bar-chart" /> Bar Chart</Radio.Button>
+                    <Radio.Button value='pie'><Icon type="pie-chart" /> Pie Chart</Radio.Button>
+                </Radio.Group>
                 <Chart></Chart> 
             </div>
-    
 };
 
 export default React.memo(CategoryChart);


### PR DESCRIPTION
Coming from lighterpack, I'm certainly used to viewing my weight breakdown in a pie chart. I added a select box to let the user choose which chart type they'd like to look at and implemented a pie chart using the `rechart` dependency we're already using for the bar chart. 

![image](https://user-images.githubusercontent.com/1940054/107961213-9532f900-6f73-11eb-959d-c7cd53897167.png)

https://user-images.githubusercontent.com/1940054/107961312-bac00280-6f73-11eb-8ecf-c16cd550374e.mp4

I figured it's also what is advertised on the homepage ;) 

![image](https://user-images.githubusercontent.com/1940054/107890453-3758cf80-6ee7-11eb-8f72-52925e2360c9.png)




