### PR TITLE
Add "Big 3" to pack weight breakdown display

### DIFF
--- a/frontend/config/webpackDevServer.config.js
+++ b/frontend/config/webpackDevServer.config.js
@@ -98,7 +98,7 @@ module.exports = function(proxy, allowedHost) {
       // We do this in development to avoid hitting the production cache if
       // it used the same host and port.
       // https://github.com/facebook/create-react-app/issues/2272#issuecomment-302832432
-      app.use(noopServiceWorkerMiddleware());
+      app.use(noopServiceWorkerMiddleware('/'));
     },
   };
 };

--- a/frontend/src/app/components/CategoryTable/index.tsx
+++ b/frontend/src/app/components/CategoryTable/index.tsx
@@ -23,6 +23,8 @@ const CategoryChart: React.FC<CategoryTableProps> = ({ data, unit }) => {
     ));
 
     const totalWeight = data.reduce((acc: number, cur: CategoryItemSpecs) => acc + cur.total.value, 0);
+    const bigThree = data.filter(({name}) => name === 'Pack' || name === 'Shelter' || name === 'Sleep System');
+    const bigThreeWeight = bigThree.reduce((sum, dat) => sum + dat.total.value, 0);
     const excludedWeight = data.reduce((acc: number, cur: CategoryItemSpecs) => acc + cur.excluded.value, 0);
     const consumables = data.find(c => c.name === 'Consumables');
     const consumablesWeight = consumables ? consumables.total.value : 0;
@@ -38,6 +40,10 @@ const CategoryChart: React.FC<CategoryTableProps> = ({ data, unit }) => {
             <CatRow className="totals highlight">
                 <div>Total</div>
                 <div>{totalWeight.toFixed(2)} {unit}</div>
+            </CatRow>
+            <CatRow className="totals">
+                <div>Big 3</div>
+                <div>{bigThreeWeight.toFixed(2)} {unit}</div>
             </CatRow>
             <CatRow className="totals">
                 <div>Consumable</div>

--- a/frontend/src/app/components/Header/index.tsx
+++ b/frontend/src/app/components/Header/index.tsx
@@ -61,7 +61,7 @@ const Header: React.FC<RouteComponentProps> = ({ history }) => {
                 <Link to={NEW_PACK}>Create Pack</Link>
             </Menu.Item>
             <Menu.Item key={PROFILE}>
-                <Link to={PROFILE}>Your Packs</Link>
+                <Link to={PROFILE}>My Packs</Link>
             </Menu.Item>
             <Menu.Divider/>
             <Menu.Item key="logout" onClick={() => app.logout()}>


### PR DESCRIPTION
Closes https://github.com/maplethorpej/packstack/issues/68

<img width="502" alt="Screenshot 2021-04-03 at 15 09 35" src="https://user-images.githubusercontent.com/8898786/113481245-4e03b780-9490-11eb-852b-dec65d5e28b9.png">

In this PR I also have a couple of other little things:
- In the collapsed nav menu we had `Your Packs` whereas we have `My Packs` in the uncollapsed menu. I updated this to match up.
- `yarn start` kept failing for me with `TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received type undefined`. The fix is in `frontend/config/webpackDevServer.config.js` but I am not sure of the cause of the error. Can remove this commit if preferred.